### PR TITLE
add JUnit report

### DIFF
--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -170,6 +170,10 @@ while echo "$1" | grep -- ^- >/dev/null 2>&1; do
             COVERAGE=1;;
         # JUnit report
         -j)
+			if [[ ${SAXON_CP} != *"saxon9pe"* && ${SAXON_CP} != *"saxon9ee"* ]]; then
+				echo "JUnit report requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
+			    exit 1
+			fi
             JUNIT=1;;
         # Help!
         -h)

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -170,8 +170,8 @@ while echo "$1" | grep -- ^- >/dev/null 2>&1; do
             COVERAGE=1;;
         # JUnit report
         -j)
-			if [[ ${SAXON_CP} != *"saxon9pe"* && ${SAXON_CP} != *"saxon9ee"* ]]; then
-				echo "JUnit report requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE."
+			if [[ ${SAXON_CP} == *"saxon8"* || ${SAXON_CP} == *"saxon8sa"* ]]; then
+				echo "Saxon8 detected. JUnit report requires Saxon9."
 			    exit 1
 			fi
             JUNIT=1;;

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -36,12 +36,13 @@ usage() {
         echo "$1"
         echo;
     fi
-    echo "Usage: xspec [-t|-q|-c|-h] filename [coverage]"
+    echo "Usage: xspec [-t|-q|-c|-j|-h] filename [coverage]"
     echo
     echo "  filename   the XSpec document"
     echo "  -t         test an XSLT stylesheet (the default)"
     echo "  -q         test an XQuery module (mutually exclusive with -t)"
     echo "  -c         output test coverage report"
+    echo "  -j         output JUnit report"
     echo "  -h         display this help message"
     echo "  coverage   deprecated, use -c instead"
 }
@@ -167,6 +168,9 @@ while echo "$1" | grep -- ^- >/dev/null 2>&1; do
         # Coverage
         -c)
             COVERAGE=1;;
+        # JUnit report
+        -j)
+            JUNIT=1;;
         # Help!
         -h)
             usage
@@ -219,6 +223,7 @@ COVERAGE_XML=$TEST_DIR/$TARGET_FILE_NAME-coverage.xml
 COVERAGE_HTML=$TEST_DIR/$TARGET_FILE_NAME-coverage.html
 RESULT=$TEST_DIR/$TARGET_FILE_NAME-result.xml
 HTML=$TEST_DIR/$TARGET_FILE_NAME-result.html
+JUNIT_RESULT=$TEST_DIR/$TARGET_FILE_NAME-junit.xml
 COVERAGE_CLASS=com.jenitennison.xslt.tests.XSLTCoverageTraceListener
 
 if [ ! -d "$TEST_DIR" ]; then
@@ -293,6 +298,12 @@ if test -n "$COVERAGE"; then
         || die "Error formating the coverage report"
     echo "Report available at $COVERAGE_HTML"
     #$OPEN "$COVERAGE_HTML"
+elif test -n "$JUNIT"; then
+	xslt -o:"$JUNIT_RESULT" \
+		-s:"$RESULT" \
+		-xsl:"$XSPEC_HOME/src/reporter/junit-report.xsl" \
+		|| die "Error formating the JUnit report"
+	echo "Report available at $JUNIT_RESULT"
 else
     echo "Report available at $HTML"
     #$OPEN "$HTML"

--- a/src/reporter/junit-report.xsl
+++ b/src/reporter/junit-report.xsl
@@ -9,22 +9,21 @@
 		Executed from bin/xspec.sh
   Input:        XSpec XML report                             
   Output:       JUnit report                                                         
-  Dependencies: This XSLT requires Saxon9EE or Saxon9PE 
-		as it uses the extension function saxon:serialize() 
+  Dependencies: It requires XSLT 3.0 for function fn:serialize() 
   Authors:      Kal Ahmed, github.com/kal       
 		Sandro Cirulli, github.com/cirulls
   License: 	MIT License (https://opensource.org/licenses/MIT)
 
   ======================================================================== -->
-<xsl:stylesheet version="2.0"
+<xsl:stylesheet version="3.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:x="http://www.jenitennison.com/xslt/xspec"
                 xmlns:test="http://www.jenitennison.com/xslt/unit-test"
                 xmlns:pkg="http://expath.org/ns/pkg"
                 xmlns:xhtml="http://www.w3.org/1999/xhtml"
-                xmlns:saxon="http://saxon.sf.net/"
-                exclude-result-prefixes="x xs test pkg xhtml saxon">
+                xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                exclude-result-prefixes="x xs test pkg xhtml fn">
         
     <xsl:output name="escaped" method="xml" omit-xml-declaration="yes" indent="yes"/>
 
@@ -82,7 +81,7 @@
     </xsl:template>
     
     <xsl:template match="x:expect">
-        <xsl:value-of select="saxon:serialize(., 'escaped')"></xsl:value-of>
+        <xsl:value-of select="fn:serialize(.)"></xsl:value-of>
     </xsl:template>
     
 </xsl:stylesheet>

--- a/src/reporter/junit-report.xsl
+++ b/src/reporter/junit-report.xsl
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- =====================================================================
+
+  Usage:	java -cp "$CP" net.sf.saxon.Transform 
+		-o:"$JUNIT_RESULT" \
+	        -s:"$RESULT" \
+	        -xsl:"$XSPEC_HOME/src/reporter/junit-report.xsl"
+  Description:  XSLT to convert XSpec XML report to JUnit report                                       
+		Executed from bin/xspec.sh
+  Input:        XSpec XML report                             
+  Output:       JUnit report                                                         
+  Dependencies: This XSLT requires Saxon9EE or Saxon9PE 
+		as it uses the extension function saxon:serialize() 
+  Authors:      Kal Ahmed, github.com/kal       
+		Sandro Cirulli, github.com/cirulls
+  License: 	MIT License (https://opensource.org/licenses/MIT)
+
+  ======================================================================== -->
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:x="http://www.jenitennison.com/xslt/xspec"
+                xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+                xmlns:pkg="http://expath.org/ns/pkg"
+                xmlns:xhtml="http://www.w3.org/1999/xhtml"
+                xmlns:saxon="http://saxon.sf.net/"
+                exclude-result-prefixes="x xs test pkg xhtml saxon">
+        
+    <xsl:output name="escaped" method="xml" omit-xml-declaration="yes" indent="yes"/>
+
+    <xsl:template match="x:report">
+        <testsuites>
+            <xsl:apply-templates select="x:scenario"/>
+        </testsuites>
+    </xsl:template>
+    
+    <xsl:template match="x:scenario">
+        <testsuite>
+            <xsl:attribute name="name" select="x:label"/>
+            <xsl:attribute name="tests" select="count(.//x:test)"/>
+            <xsl:attribute name="failures" select="count(.//x:test[@successful='false'])"/>
+            <xsl:apply-templates select="x:test"/>
+            <xsl:apply-templates select="x:scenario" mode="nested"/>
+        </testsuite>
+    </xsl:template>
+
+    <xsl:template match="x:scenario" mode="nested">
+        <xsl:param name="prefix" select="''"/>
+        <xsl:variable name="prefixed-label" select="concat($prefix, x:label, ' ')"/>
+        <xsl:apply-templates select="x:test">
+            <xsl:with-param name="prefix" select="$prefixed-label"/>
+        </xsl:apply-templates>
+        <xsl:apply-templates select="x:scenario" mode="nested">
+            <xsl:with-param name="prefix" select="$prefixed-label"/>
+        </xsl:apply-templates>
+    </xsl:template>
+    
+    <xsl:template match="x:test">
+        <xsl:param name="prefix"/>
+        <testcase>
+            <xsl:attribute name="name" select="concat($prefix, x:label)"/>
+            <xsl:attribute name="status">
+                <xsl:choose>
+                    <xsl:when test="@pending">skipped</xsl:when>
+                    <xsl:when test="@successful='true'">passed</xsl:when>
+                    <xsl:otherwise>failed</xsl:otherwise>
+                </xsl:choose>
+            </xsl:attribute>
+            <xsl:choose>
+                <xsl:when test="@pending"><skipped><xsl:value-of select="@pending"/></skipped></xsl:when>
+                <xsl:when test="@successful='false'">
+                    <failure message="expect assertion failed">
+                        <xsl:apply-templates select="x:expect"/>
+                    </failure>
+                </xsl:when>
+            </xsl:choose>
+        </testcase>
+    </xsl:template>
+    
+    <xsl:template match="x:expect[@select]">
+        <xsl:text>Expected: </xsl:text><xsl:value-of select="x:expect/@select"/>
+    </xsl:template>
+    
+    <xsl:template match="x:expect">
+        <xsl:value-of select="saxon:serialize(., 'escaped')"></xsl:value-of>
+    </xsl:template>
+    
+</xsl:stylesheet>

--- a/test/xspec-junit.xspec
+++ b/test/xspec-junit.xspec
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" stylesheet="../src/reporter/junit-report.xsl">
+
+    <x:scenario label="When processing a successful test">
+        <x:context>
+	      <x:test successful="true">
+		 <x:label>Successful test</x:label>
+		 <x:result>
+			<p>Foo</p>
+		 </x:result>
+		 <x:expect>
+			<p>Foo</p>
+		 </x:expect>
+	      </x:test>
+        </x:context>
+
+        <x:expect label="convert it to test case with status passed">
+	      <testcase name="Successful test" status="passed"/>
+		</x:expect>
+    </x:scenario>
+
+
+    <x:scenario label="When processing a failing test">
+        <x:context>
+	      <x:test successful="false">
+		 <x:label>failing test</x:label>
+		 <x:result>
+			<p>Foo</p>
+		 </x:result>
+		 <x:expect>
+			<p>Bar</p>
+		 </x:expect>
+	      </x:test>
+        </x:context>
+
+        <x:expect label="convert it to test case with status failed">
+	     <testcase name="failing test"
+		        status="failed">
+				<failure message="expect assertion failed">&lt;x:expect xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"&gt;
+   &lt;p&gt;Bar&lt;/p&gt;
+&lt;/x:expect&gt;</failure>
+</testcase>
+		</x:expect>
+    </x:scenario>
+
+
+    <x:scenario label="When processing successful and failing tests">
+        <x:context>
+	      <x:test successful="true">
+		 <x:label>Successful test</x:label>
+		 <x:result>
+			<p>Foo</p>
+		 </x:result>
+		 <x:expect>
+			<p>Foo</p>
+		 </x:expect>
+	      </x:test>
+	      <x:test successful="false">
+		 <x:label>Failing test</x:label>
+		 <x:result>
+			<p>Foo</p>
+		 </x:result>
+		 <x:expect>
+			<p>Bar</p>
+		 </x:expect>
+	      </x:test>
+        </x:context>
+
+        <x:expect label="convert it to test cases with status passed and failing">
+	      <testcase name="Successful test" status="passed"/>
+	     <testcase name="Failing test"
+		        status="failed">
+				<failure message="expect assertion failed">&lt;x:expect xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+          xmlns:xs="http://www.w3.org/2001/XMLSchema"
+          xmlns:test="http://www.jenitennison.com/xslt/unit-test"
+          xmlns:x="http://www.jenitennison.com/xslt/xspec"&gt;
+   &lt;p&gt;Bar&lt;/p&gt;
+&lt;/x:expect&gt;</failure>
+</testcase>
+		</x:expect>
+    </x:scenario>
+
+
+</x:description>

--- a/test/xspec-junit.xspec
+++ b/test/xspec-junit.xspec
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" stylesheet="../src/reporter/junit-report.xsl">
+<x:description xmlns:x="http://www.jenitennison.com/xslt/xspec" stylesheet="../src/reporter/junit-report.xsl" xslt-version="3.0">
 
     <x:scenario label="When processing a successful test">
         <x:context>
@@ -33,16 +33,12 @@
 	      </x:test>
         </x:context>
 
+
         <x:expect label="convert it to test case with status failed">
-	     <testcase name="failing test"
+			<testcase name="failing test"
 		        status="failed">
-				<failure message="expect assertion failed">&lt;x:expect xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
-          xmlns:test="http://www.jenitennison.com/xslt/unit-test"
-          xmlns:x="http://www.jenitennison.com/xslt/xspec"&gt;
-   &lt;p&gt;Bar&lt;/p&gt;
-&lt;/x:expect&gt;</failure>
-</testcase>
+				<failure message="expect assertion failed">&lt;x:expect xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns:x="http://www.jenitennison.com/xslt/xspec">&lt;p&gt;Bar&lt;/p&gt;&lt;/x:expect&gt;</failure>
+			</testcase>
 		</x:expect>
     </x:scenario>
 
@@ -73,13 +69,8 @@
 	      <testcase name="Successful test" status="passed"/>
 	     <testcase name="Failing test"
 		        status="failed">
-				<failure message="expect assertion failed">&lt;x:expect xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-          xmlns:xs="http://www.w3.org/2001/XMLSchema"
-          xmlns:test="http://www.jenitennison.com/xslt/unit-test"
-          xmlns:x="http://www.jenitennison.com/xslt/xspec"&gt;
-   &lt;p&gt;Bar&lt;/p&gt;
-&lt;/x:expect&gt;</failure>
-</testcase>
+				<failure message="expect assertion failed">&lt;x:expect xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:test="http://www.jenitennison.com/xslt/unit-test" xmlns:x="http://www.jenitennison.com/xslt/xspec"&gt;&lt;p&gt;Bar&lt;/p&gt;&lt;/x:expect&gt;</failure>
+		</testcase>
 		</x:expect>
     </x:scenario>
 

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1,0 +1,55 @@
+
+#!/usr/bin/env bats
+#===============================================================================
+#
+#         USAGE:  bats xspec.bats 
+#         
+#   DESCRIPTION:  Unit tests for script bin/xspec.sh 
+#
+#         INPUT:  N/A
+#
+#        OUTPUT:  Unit tests results
+#
+#  DEPENDENCIES:  This script requires bats (https://github.com/sstephenson/bats)
+#
+#        AUTHOR:  Sandro Cirulli, github.com/cirulls
+#
+#       LICENSE:  MIT License (https://opensource.org/licenses/MIT)
+#
+#===============================================================================
+
+@test "invoking xspec without arguments prints usage" {
+  run ../bin/xspec.sh
+  [ "$status" -eq 1 ]
+  [ "${lines[2]}" = "Usage: xspec [-t|-q|-c|-j|-h] filename [coverage]" ]
+}
+
+@test "invoking xspec generates XML report file" {
+  run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+  run stat ../tutorial/xspec/escape-for-regex-result.xml
+  [ "$status" -eq 0 ]
+}
+
+@test "invoking xspec generates HTML report file" {
+  run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+  run stat ../tutorial/xspec/escape-for-regex-result.html
+  [ "$status" -eq 0 ]
+}
+
+@test "invoking xspec with -j option generates message with JUnit report location" {
+  run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+  [ "$status" -eq 0 ]
+  [ "${lines[18]}" = "Report available at ../tutorial/xspec/escape-for-regex-junit.xml" ]
+}
+
+@test "invoking xspec with -j option generates XML report file" {
+  run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+  run stat ../tutorial/xspec/escape-for-regex-result.xml
+  [ "$status" -eq 0 ]
+}
+
+@test "invoking xspec with -j option generates JUnit report file" {
+  run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+  run stat ../tutorial/xspec/escape-for-regex-junit.xml
+  [ "$status" -eq 0 ]
+}

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -24,6 +24,7 @@
   [ "${lines[2]}" = "Usage: xspec [-t|-q|-c|-j|-h] filename [coverage]" ]
 }
 
+
 @test "invoking xspec generates XML report file" {
   run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
   run stat ../tutorial/xspec/escape-for-regex-result.xml
@@ -35,6 +36,14 @@
   run stat ../tutorial/xspec/escape-for-regex-result.html
   [ "$status" -eq 0 ]
 }
+
+@test "invoking xspec with -j option with Saxon9HE returns error message" {
+  export SAXON_CP=/path/to/saxon9he.jar
+  run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+  [ "$status" -eq 1 ]
+  [ "${lines[1]}" = "JUnit report requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+}
+
 
 @test "invoking xspec with -j option generates message with JUnit report location" {
   run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -37,11 +37,19 @@
   [ "$status" -eq 0 ]
 }
 
-@test "invoking xspec with -j option with Saxon9HE returns error message" {
-  export SAXON_CP=/path/to/saxon9he.jar
+@test "invoking xspec with -j option with Saxon8 returns error message" {
+  export SAXON_CP=/path/to/saxon8.jar
   run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
   [ "$status" -eq 1 ]
-  [ "${lines[1]}" = "JUnit report requires Saxon extension functions which are available only under Saxon9EE or Saxon9PE." ]
+  [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
+}
+
+
+@test "invoking xspec with -j option with Saxon8-SA returns error message" {
+  export SAXON_CP=/path/to/saxon8sa.jar
+  run ../bin/xspec.sh -j ../tutorial/escape-for-regex.xspec
+  [ "$status" -eq 1 ]
+  [ "${lines[1]}" = "Saxon8 detected. JUnit report requires Saxon9." ]
 }
 
 


### PR DESCRIPTION
This pull request adds the functionality to generate a JUnit XML report. This is useful when running XSpec tests on Continuous Integration servers like Jenkins that understand JUnit natively. This pull request addresses a functionality requested in https://github.com/expath/xspec/issues/47. Note that this requires Saxon9-EE or Saxon9-PE as the generation of the JUnit report requires Saxon extension functions. 
## Technical notes

I described here what I added. 

The shell script [xspec.sh](https://github.com/cirulls/xspec/blob/feature/junit/bin/xspec.sh) now contains a `-j` flag that allows to run the shell script with the option of generating a JUnit report. The report is generated via the XSLT [junit-report.xsl](https://github.com/cirulls/xspec/blob/feature/junit/src/reporter/junit-report.xsl) that takes as input the XSpec XML report and generate a JUnit XML report in the same directory where the reports are kept. 

This feature requires Saxon9-EE or Saxon9-PE as it makes use of Saxon extension functions. When executed with another Saxon version (e.g. Saxon9-HE) the script outputs an error message requesting the correct version of Saxon. 

I show here below some screenshots when XSpec is executed within Jenkins (I used the default example provided in XSpec, this could be useful for documentation purposes).

In the pull request I include unit tests for the shell script (see [xspec.bats](https://github.com/cirulls/xspec/blob/feature/junit/test/xspec.bats)) and XSpec tests for the XSLT transforming the report into JUnit (see [xspec-junit.xspec](https://github.com/cirulls/xspec/blob/feature/junit/test/xspec-junit.xspec)).

![jenkins_build_configuration](https://cloud.githubusercontent.com/assets/13256236/17651882/5b62c9f8-6267-11e6-953d-0af94509663f.png)
![jenkins_build_trend](https://cloud.githubusercontent.com/assets/13256236/17651895/d5857226-6267-11e6-9521-0c24cfde23dd.png)
![jenkins_failing_xspec_test](https://cloud.githubusercontent.com/assets/13256236/17651894/d5829f4c-6267-11e6-922e-d52fa4d26661.png)
