### PR TITLE
add support for Saxon-B (#79)

### DIFF
--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -132,6 +132,8 @@ if test -z "$SAXON_CP"; then
 	SAXON_CP="${SAXON_HOME}/saxon9sa.jar";
     elif test -f "${SAXON_HOME}/saxon9.jar"; then
 	SAXON_CP="${SAXON_HOME}/saxon9.jar";
+    elif test -f "${SAXON_HOME}/saxon9-1-0-8.jar"; then
+	SAXON_CP="${SAXON_HOME}/saxon9-1-0-8.jar";
     elif test -f "${SAXON_HOME}/saxon8sa.jar"; then
 	SAXON_CP="${SAXON_HOME}/saxon8sa.jar";
     elif test -f "${SAXON_HOME}/saxon8.jar"; then

--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -132,8 +132,8 @@ if test -z "$SAXON_CP"; then
 	SAXON_CP="${SAXON_HOME}/saxon9sa.jar";
     elif test -f "${SAXON_HOME}/saxon9.jar"; then
 	SAXON_CP="${SAXON_HOME}/saxon9.jar";
-    elif test -f "${SAXON_HOME}/saxon9-1-0-8.jar"; then
-	SAXON_CP="${SAXON_HOME}/saxon9-1-0-8.jar";
+    elif test -f "${SAXON_HOME}/saxonb9-1-0-8.jar"; then
+	SAXON_CP="${SAXON_HOME}/saxonb9-1-0-8.jar";
     elif test -f "${SAXON_HOME}/saxon8sa.jar"; then
 	SAXON_CP="${SAXON_HOME}/saxon8sa.jar";
     elif test -f "${SAXON_HOME}/saxon8.jar"; then

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -18,14 +18,14 @@
 #===============================================================================
 
 
-@test "invoking xspec with Saxon9-1-0-8 (Saxon-B) returns correct version number at compile time" {
+@test "invoking xspec with Saxon-B-9-1-0-8 returns correct version number at compile time" {
 	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 	[ "$status" -eq 0 ]
   	[ "${lines[3]}" = "Testing with SAXON 9.1.0.8" ]
 }
 
 
-@test "invoking xspec with Saxon9-1-0-8 (Saxon-B) creates test stylesheet" {
+@test "invoking xspec with Saxon-B-9-1-0-8 creates test stylesheet" {
 	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
 	[ "$status" -eq 0 ]
   	[ "${lines[1]}" = "Creating Test Stylesheet..." ]

--- a/test/xspec.bats
+++ b/test/xspec.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+#===============================================================================
+#
+#         USAGE:  bats xspec.bats 
+#         
+#   DESCRIPTION:  Unit tests for script bin/xspec.sh 
+#
+#         INPUT:  N/A
+#
+#        OUTPUT:  Unit tests results
+#
+#  DEPENDENCIES:  This script requires bats (https://github.com/sstephenson/bats)
+#
+#        AUTHOR:  Sandro Cirulli, github.com/cirulls
+#
+#       LICENSE:  MIT License (https://opensource.org/licenses/MIT)
+#
+#===============================================================================
+
+
+@test "invoking xspec with Saxon9-1-0-8 (Saxon-B) returns correct version number at compile time" {
+	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+	[ "$status" -eq 0 ]
+  	[ "${lines[3]}" = "Testing with SAXON 9.1.0.8" ]
+}
+
+
+@test "invoking xspec with Saxon9-1-0-8 (Saxon-B) creates test stylesheet" {
+	run ../bin/xspec.sh ../tutorial/escape-for-regex.xspec
+	[ "$status" -eq 0 ]
+  	[ "${lines[1]}" = "Creating Test Stylesheet..." ]
+}


### PR DESCRIPTION
This pull request addresses #79 raised by @magwas and adds support for Saxon B 9-1-0-8 in the shell script [xspec.sh](https://github.com/cirulls/xspec/blob/feature/saxon-b/bin/xspec.sh). 

This is what I did:
- add condition to detect Saxon B 9-1-0-8. The jar file must be named `saxonb9-1-0-8.jar`, this seems to me the standard convention for the latest version of Saxon-B (see https://sourceforge.net/projects/saxon/files/Saxon-B/9.1.0.8/) 
- add bats unit tests for shell script
