### PR TITLE
Fixed TEST_DIR management

### DIFF
--- a/bin/xspec.sh
+++ b/bin/xspec.sh
@@ -207,7 +207,10 @@ fi
 ## files and dirs ############################################################
 ##
 
-TEST_DIR=$(dirname "$XSPEC")/xspec
+if [ -z "$TEST_DIR" ]
+then
+    TEST_DIR=$(dirname "$XSPEC")/xspec
+fi
 TARGET_FILE_NAME=$(basename "$XSPEC" | sed 's:\...*$::')
 
 if test -n "$XSLT"; then


### PR DESCRIPTION
TEST_DIR was set in script even if already set in environment. Added a test so that it is not set if already defined.
