### PR TITLE
allow to set custom location of TEST_DIR on batch script

### DIFF
--- a/bin/xspec.bat
+++ b/bin/xspec.bat
@@ -27,7 +27,7 @@ GOTO end
 
 SET COVERAGE=%2
 
-SET TEST_DIR=%~dp1xspec
+IF "%TEST_DIR%"=="" SET TEST_DIR=%~dp1xspec
 SET TARGET_FILE_NAME=%~n1
 
 SET TEST_STYLESHEET="%TEST_DIR%\%TARGET_FILE_NAME%.xsl"
@@ -89,7 +89,7 @@ GOTO endif4
 REM =============
 REM Output report
 REM =============
-%HTML%
+echo Report available at %HTML%
 
 echo Done.
 :end


### PR DESCRIPTION
- allow to set a custom location of TEST_DIR for HTML reports on batch script (in line with #83)
- fix error message on batch script for opening HTML report (https://github.com/cirulls/xspec/issues/16)

@c4s4 sent pull request #83 to allow the setting of a custom location for TEST_DIR in the shell script [bin/xspec.sh](https://github.com/expath/xspec/blob/master/bin/xspec.sh). He also sent another [pull request to my fork](https://github.com/cirulls/xspec/pull/14) to apply the same feature to the Windows batch script. I reviewed his pull requests and tested them successfully on a Windows-like system. 

I also include a bug fix on the batch script which is described in [my fork](https://github.com/cirulls/xspec/issues/16).
